### PR TITLE
 ci/build: Windows CI and CUDA architecture auto-detection

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,6 +61,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements.txt -r requirements-dev.txt
 
       - name: Install build tools
         run: |
@@ -44,13 +44,13 @@ jobs:
       - name: Run tests (compiled backend)
         env:
           PYTHONPATH: ${{ github.workspace }}
-        run: pytest tests/ -v --tb=short --cov=hoshicore --cov-report=term-missing -x
+        run: python -m pytest tests/ -v --tb=short --cov=hoshicore --cov-report=term-missing -x
 
       - name: Run tests (numpy fallback)
         env:
           PYTHONPATH: ${{ github.workspace }}
           HNW_CUSTOM_OPS_FALLBACK: numpy
-        run: pytest tests/ -v --tb=short -x
+        run: python -m pytest tests/ -v --tb=short -x
 
   test-windows:
     runs-on: windows-latest
@@ -79,7 +79,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements.txt -r requirements-dev.txt
 
       - name: Build C++ custom ops
         run: python csrc/build_ops.py --compiler msvc
@@ -87,10 +87,10 @@ jobs:
       - name: Run tests (compiled backend)
         env:
           PYTHONPATH: ${{ github.workspace }}
-        run: pytest tests/ -v --tb=short -x
+        run: python -m pytest tests/ -v --tb=short -x
 
       - name: Run tests (numpy fallback)
         env:
           PYTHONPATH: ${{ github.workspace }}
           HNW_CUSTOM_OPS_FALLBACK: numpy
-        run: pytest tests/ -v --tb=short -x
+        run: python -m pytest tests/ -v --tb=short -x

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  test-linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -45,6 +45,46 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}
         run: pytest tests/ -v --tb=short --cov=hoshicore --cov-report=term-missing -x
+
+      - name: Run tests (numpy fallback)
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          HNW_CUSTOM_OPS_FALLBACK: numpy
+        run: pytest tests/ -v --tb=short -x
+
+  test-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build C++ custom ops
+        run: python csrc/build_ops.py --compiler msvc
+
+      - name: Run tests (compiled backend)
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: pytest tests/ -v --tb=short -x
 
       - name: Run tests (numpy fallback)
         env:

--- a/csrc/README.md
+++ b/csrc/README.md
@@ -132,39 +132,38 @@ python csrc/build_ops.py --dry-run
 
 ## 打包约定
 
-最终发布为 PyInstaller single-folder 模式。OpenMP 和 CUDA runtime 均**静态链接**到 `_C`
-扩展模块内，打包时只需收集 `_C.so`（Linux）/ `_C.pyd`（Windows）本身，
-无需额外携带 `libgomp.so`、`vcomp140.dll` 或 `cudart64_*.dll`。
+最终发布为 PyInstaller single-folder 模式。CUDA runtime 静态链接到 `_C`；
+OpenMP 在 Linux/Windows 为动态链接（PyInstaller 自动收集），macOS 为静态链接。
 
-### 静态链接策略
+### 链接策略
 
-| 依赖 | 编译方式 | 说明 |
+| 依赖 | 链接方式 | 说明 |
 |------|----------|------|
-| OpenMP (Linux + GCC) | `-static-libgomp` 或 link `libgomp.a` | 线程池实现烤进 `_C.so` |
-| OpenMP (Windows + MSVC) | `/openmp` + 静态 CRT（`/MT`）| `vcomp140.dll` 依赖消除；若用 LLVM OpenMP 则嵌入 libomp |
-| OpenMP (macOS) | 静态链接 Homebrew `libomp.a` | 需先 `brew install libomp`，编译时自动检测并静态链接 |
-| CUDA runtime | `CUDA_USE_STATIC_CUDA_RUNTIME=ON`，link `cudart_static` | NVIDIA 官方支持，消除 `libcudart.so` / `cudart64_*.dll` 依赖 |
+| OpenMP (Linux + GCC) | 动态（`libgomp.so`） | 系统自带，PyInstaller 自动收集到产物目录 |
+| OpenMP (Windows + MSVC) | 动态（`vcomp140.dll`） | VC++ Redistributable 组件，PyInstaller 自动收集 |
+| OpenMP (macOS) | 静态（Homebrew `libomp.a`） | 需先 `brew install libomp`，编译时自动检测并静态链接 |
+| CUDA runtime | 静态（`cudart_static`） | 消除 `libcudart.so` / `cudart64_*.dll` 依赖 |
 
 ### 无法静态链接的部分
 
 - **NVIDIA driver**（`libcuda.so` / `nvcuda.dll`）：属于内核态接口，必须由用户机器提供
 - 用户只需安装与本机 GPU 匹配的 NVIDIA 驱动，不需要 CUDA Toolkit
 
-### 验证依赖是否干净
+### 验证依赖
 
 ```bash
-# Linux — 确认不再依赖 libgomp / libcudart
+# Linux — 确认 cudart 已静态链接，libgomp 为动态（PyInstaller 会收集）
 ldd hoshicore/_custom_op/_C*.so | grep -E “cudart|gomp”
-# 预期：无输出
+# 预期：只看到 libgomp.so，不应出现 libcudart.so
 
 # Windows (Developer Command Prompt)
 dumpbin /dependents hoshicore/_custom_op/_C*.pyd
-# 预期：不出现 vcomp140.dll / cudart64_*.dll
+# 预期：出现 VCOMP140.DLL（正常），不应出现 cudart64_*.dll
 ```
 
 ### PyInstaller 收集
 
-静态链接后，`_C` 无额外运行时库依赖。spec file 只需确保 `_C` 模块本身被收集：
+OpenMP 动态库由 PyInstaller 自动收集。spec file 确保 `_C` 模块被包含即可：
 
 ```python
 # PyInstaller spec — hiddenimports 确保 _C 被打包

--- a/csrc/cmake/HnwCuda.cmake
+++ b/csrc/cmake/HnwCuda.cmake
@@ -1,8 +1,24 @@
 macro(hnw_enable_cuda_language)
     if(HNW_ENABLE_CUDA)
-        enable_language(CUDA)
-        include(CMakeCUDAInformation)
+        # Detect toolkit version first to choose architectures
         find_package(CUDAToolkit REQUIRED)
+
+        if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+            # Pascal (60) through latest supported by detected toolkit
+            set(CMAKE_CUDA_ARCHITECTURES "60;70;75;80;86")
+            if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "11.8")
+                list(APPEND CMAKE_CUDA_ARCHITECTURES 89)
+            endif()
+            if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "12.0")
+                list(APPEND CMAKE_CUDA_ARCHITECTURES 90)
+            endif()
+            if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "12.8")
+                list(APPEND CMAKE_CUDA_ARCHITECTURES 100)
+            endif()
+            message(STATUS "CUDA architectures (auto): ${CMAKE_CUDA_ARCHITECTURES}")
+        endif()
+
+        enable_language(CUDA)
     endif()
 endmacro()
 

--- a/tests/test_custom_ops.py
+++ b/tests/test_custom_ops.py
@@ -701,6 +701,10 @@ class TestCustomOpsFallback(unittest.TestCase):
             def __getitem__(self, idx):
                 return self._items[idx]
 
+            async def iter_prefetch(self, start=0, stop=None):
+                for item in self._items[start:stop]:
+                    yield item
+
             def cleanup(self):
                 self.cleaned = True
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  - Add Windows MSVC build and test job to CI (compiled + numpy fallback)                                                                                                                                           
  - Auto-detect CUDA architectures based on toolkit version (Pascal 60 through Blackwell 100)                                                                                                                       
  - Fix OpenMP linking docs to match actual behavior (Linux/Windows dynamic, macOS static)   
                                                                                                                                                                                                                    
  ## Changes                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  - `.github/workflows/test.yaml`: add `test-windows` job with `ilammy/msvc-dev-cmd`                                                                                                                                
  - `csrc/cmake/HnwCuda.cmake`: auto-select arch list based on `CUDAToolkit_VERSION`                                                                                                                                
  - `csrc/README.md`: correct OpenMP linking strategy documentation                                                                                                                                                 
                                                                                                                                                                                                                    
  ## Test plan                                                                                                                                                                                                      
                                                                                                                                                                                                                    
  - [x] Linux GCC build verified locally                                                                                                                                                                            
  - [x] Windows MSVC build verified locally (CPU + CUDA)                                                                                                                                                            
  - [x] CI passes (Linux + Windows, Python 3.11/3.12)   