### PR TITLE
feat: support native integer types in median_reduce_chunk

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -139,14 +139,13 @@ python -m bench.data_tools.generate_starfield_dataset --name align_u16_32f --fra
 - `compare_remap` 的口径是“当前 CPU 原方案总时间”对比 “Triton GPU 原型总时间”。
 - `compare_homography` 只覆盖纯 warp kernel，不代表整条无相机参数对齐路径。
 - 当前正式保留的 GPU custom-op 只有 fused `camera_model_remap`；`homography` custom-op 试验已撤回。
-- `median_reduce_chunk_baseline` 对齐当前 `MedianReduceOp` 主线的 chunk 处理：逐块分配 `float32` stack、逐帧拷贝切片、再执行 `np.median(axis=0)`。
 
 示例：
 
 ```bash
 python -m bench.cpu.kernels --frames 128 --height 1080 --width 1920 --dtype uint16 --input-mode synthetic
 python -m bench.cpu.kernels --frames 64 --height 2048 --width 3072 --dtype uint16 --input-mode synthetic --cases fgp_masked_mean_merge_stream_numpy,fgp_masked_mean_merge_stream_compiled,sigma_clip_fused_merge_stream_numpy,sigma_clip_fused_merge_stream_compiled,sigma_clip_fused_masked_merge_stream_numpy,sigma_clip_fused_masked_merge_stream_compiled,fgp_add_partial_reduce_numpy,fgp_add_partial_reduce_compiled
-python -m bench.cpu.kernels --frames 16 --height 2048 --width 3072 --dtype uint16 --input-mode synthetic --cases median_reduce_chunk_baseline --chunk-rows 32
+python -m bench.cpu.kernels --frames 16 --height 2048 --width 3072 --dtype uint16 --input-mode synthetic --cases median_reduce_chunk_numpy,median_reduce_chunk_compiled --chunk-rows 32
 python -m bench.cpu.max_stack --frames 100 --height 4000 --width 6000 --dtype uint8 --workers 4 --openmp-threads auto --input-mode cache
 python -m bench.cpu.fgp_accumulate --frames 100 --height 4000 --width 6000 --dtype uint8 --openmp-threads auto --input-mode cache
 python -m bench.cpu.max_stack --frames 1000 --input-dir bench/data/cache/max_u8_100x24mp_cache --output-json bench-results/max-1000.json

--- a/bench/cpu/kernels.py
+++ b/bench/cpu/kernels.py
@@ -434,34 +434,6 @@ def bench_huber_pass(frames: list[np.ndarray], weights: list[float], int_weight:
     _ = huber.merged_image
 
 
-def bench_median_reduce_chunk_baseline(
-    frames: list[np.ndarray],
-    chunk_rows: int,
-) -> None:
-    """Mirror the current MedianReduceOp inner chunk loop.
-
-    This is intentionally a baseline-only benchmark: it preallocates a float32
-    stack per chunk, copies each frame slice into that stack, then runs
-    `np.median(..., axis=0)`. The goal is to quantify the real mainline cost
-    before deciding whether a native implementation is justified.
-    """
-    first = frames[0]
-    h, w = first.shape[:2]
-    channels = first.shape[2] if first.ndim == 3 else None
-
-    for row_start in range(0, h, chunk_rows):
-        row_end = min(row_start + chunk_rows, h)
-        actual_rows = row_end - row_start
-        if channels is None:
-            stack = np.empty((len(frames), actual_rows, w), dtype=np.float32)
-        else:
-            stack = np.empty((len(frames), actual_rows, w, channels),
-                             dtype=np.float32)
-        for frame_idx, frame in enumerate(frames):
-            stack[frame_idx] = frame[row_start:row_end].astype(np.float32)
-        _ = np.median(stack, axis=0)
-
-
 def build_median_chunk_stacks(
     frames: list[np.ndarray],
     chunk_rows: int,
@@ -469,17 +441,18 @@ def build_median_chunk_stacks(
     first = frames[0]
     h, w = first.shape[:2]
     channels = first.shape[2] if first.ndim == 3 else None
+    dtype = first.dtype
     stacks: list[np.ndarray] = []
     for row_start in range(0, h, chunk_rows):
         row_end = min(row_start + chunk_rows, h)
         actual_rows = row_end - row_start
         if channels is None:
-            stack = np.empty((len(frames), actual_rows, w), dtype=np.float32)
+            stack = np.empty((len(frames), actual_rows, w), dtype=dtype)
         else:
             stack = np.empty((len(frames), actual_rows, w, channels),
-                             dtype=np.float32)
+                             dtype=dtype)
         for frame_idx, frame in enumerate(frames):
-            stack[frame_idx] = frame[row_start:row_end].astype(np.float32)
+            stack[frame_idx] = frame[row_start:row_end]
         stacks.append(stack)
     return stacks
 
@@ -632,8 +605,6 @@ def main() -> None:
         ),
         "sigma_clip_pass": lambda: bench_sigma_clip_pass(frames, weights, True),
         "huber_pass": lambda: bench_huber_pass(frames, weights, True),
-        "median_reduce_chunk_baseline": lambda: bench_median_reduce_chunk_baseline(
-            frames, args.chunk_rows),
         "median_reduce_chunk_numpy": lambda: bench_median_reduce_chunk_backend(
             median_chunk_stacks,
             backend="numpy",
@@ -642,8 +613,6 @@ def main() -> None:
             median_chunk_stacks,
             backend="compiled",
         ),
-        "median_chunk": lambda: bench_median_reduce_chunk_baseline(
-            frames, args.chunk_rows),
     }
     selected_cases = requested_cases or list(registry.keys())
     for case_name in selected_cases:

--- a/csrc/cmake/HnwOpenMP.cmake
+++ b/csrc/cmake/HnwOpenMP.cmake
@@ -26,7 +26,8 @@ function(hnw_link_openmp target_name)
         # MSVC: /openmp is a compile-only flag; vcomp140.dll is implicitly linked.
         # Cannot statically link MSVC OpenMP runtime in a Python extension (.pyd).
         # PyInstaller will collect vcomp140.dll automatically.
-        target_compile_options("${target_name}" PRIVATE /openmp)
+        # Use generator expression to avoid passing /openmp to nvcc.
+        target_compile_options("${target_name}" PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/openmp>)
     else()
         find_package(OpenMP REQUIRED COMPONENTS CXX)
         target_link_libraries("${target_name}" PRIVATE OpenMP::OpenMP_CXX)

--- a/csrc/ops/median/median_ops.cpp
+++ b/csrc/ops/median/median_ops.cpp
@@ -1,8 +1,10 @@
 #include "median_ops.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <pybind11/numpy.h>
@@ -20,6 +22,16 @@ namespace {
 #else
 #define HNW_RESTRICT
 #endif
+
+template <typename T>
+inline T median_average(T low, T high) {
+    if constexpr (std::is_floating_point_v<T>) {
+        return (low + high) * static_cast<T>(0.5);
+    } else {
+        // Integer types: use widened arithmetic to avoid overflow
+        return static_cast<T>((static_cast<int64_t>(low) + static_cast<int64_t>(high)) / 2);
+    }
+}
 
 template <typename T>
 void median_reduce_chunk_kernel(
@@ -59,7 +71,7 @@ void median_reduce_chunk_kernel(
                 scratch.begin() + (mid - 1),
                 scratch.begin() + mid);
             const T low = scratch[static_cast<size_t>(mid - 1)];
-            out_ptr[idx] = static_cast<T>((low + high) * static_cast<T>(0.5));
+            out_ptr[idx] = median_average(low, high);
         }
     }
 #else
@@ -84,7 +96,7 @@ void median_reduce_chunk_kernel(
             scratch.begin() + (mid - 1),
             scratch.begin() + mid);
         const T low = scratch[static_cast<size_t>(mid - 1)];
-        out_ptr[idx] = static_cast<T>((low + high) * static_cast<T>(0.5));
+        out_ptr[idx] = median_average(low, high);
     }
 #endif
 }
@@ -114,6 +126,14 @@ py::array_t<T> median_reduce_chunk_impl(
 }
 
 py::array median_reduce_chunk_dispatch(const py::array& stack) {
+    if (py::isinstance<py::array_t<uint8_t>>(stack)) {
+        return median_reduce_chunk_impl<uint8_t>(
+            stack.cast<py::array_t<uint8_t>>());
+    }
+    if (py::isinstance<py::array_t<uint16_t>>(stack)) {
+        return median_reduce_chunk_impl<uint16_t>(
+            stack.cast<py::array_t<uint16_t>>());
+    }
     if (py::isinstance<py::array_t<float>>(stack)) {
         return median_reduce_chunk_impl<float>(
             stack.cast<py::array_t<float>>());
@@ -123,7 +143,7 @@ py::array median_reduce_chunk_dispatch(const py::array& stack) {
             stack.cast<py::array_t<double>>());
     }
     throw std::invalid_argument(
-        "median_reduce_chunk: only float32/float64 stacks are supported");
+        "median_reduce_chunk: unsupported dtype; expected uint8/uint16/float32/float64");
 }
 
 }  // namespace

--- a/hoshicore/_custom_op/ops/median.py
+++ b/hoshicore/_custom_op/ops/median.py
@@ -49,6 +49,9 @@ def _load_compiled_module_result() -> tuple[Any | None, str | None]:
         return None, f"{type(exc).__name__}: {exc}"
 
 
+_SUPPORTED_DTYPES = (np.uint8, np.uint16, np.float32, np.float64)
+
+
 def _validate_stack(stack: np.ndarray) -> np.ndarray:
     stack_arr = np.asarray(stack)
     if stack_arr.ndim not in {3, 4}:
@@ -57,8 +60,11 @@ def _validate_stack(stack: np.ndarray) -> np.ndarray:
         )
     if stack_arr.shape[0] <= 0:
         raise ValueError("median_reduce_chunk: frame axis must be non-empty")
-    if not np.issubdtype(stack_arr.dtype, np.floating):
-        raise ValueError("median_reduce_chunk: floating-point stack required")
+    if stack_arr.dtype not in _SUPPORTED_DTYPES:
+        raise ValueError(
+            "median_reduce_chunk: unsupported dtype; "
+            "expected uint8/uint16/float32/float64"
+        )
     if not stack_arr.flags.c_contiguous:
         stack_arr = np.ascontiguousarray(stack_arr)
     return stack_arr
@@ -88,7 +94,11 @@ def _apply_compiled_threads(op_name: str, sample: np.ndarray) -> None:
 
 def median_reduce_chunk_numpy(stack: np.ndarray) -> np.ndarray:
     stack_arr = _validate_stack(stack)
-    return np.median(stack_arr, axis=0)
+    result = np.median(stack_arr, axis=0)
+    # np.median always returns float64; cast back to match compiled backend behavior
+    if result.dtype != stack_arr.dtype:
+        result = result.astype(stack_arr.dtype)
+    return result
 
 
 def median_reduce_chunk_compiled(stack: np.ndarray) -> np.ndarray:

--- a/hoshicore/ops/sigma_clip_ops.py
+++ b/hoshicore/ops/sigma_clip_ops.py
@@ -477,15 +477,14 @@ class MedianReduceOp(BaseOp):
                 if first_frame.ndim == 3:
                     stack = np.empty(
                         (n_frames, actual_rows, w, channels),
-                        dtype=np.float32)
+                        dtype=source_dtype)
                 else:
                     stack = np.empty(
-                        (n_frames, actual_rows, w), dtype=np.float32)
+                        (n_frames, actual_rows, w), dtype=source_dtype)
 
                 for frame_idx in range(n_frames):
                     frame_data, _ = frame_buffer[frame_idx]
-                    stack[frame_idx] = frame_data[
-                        row_start:row_end].astype(np.float32)
+                    stack[frame_idx] = frame_data[row_start:row_end]
 
                 # 沿帧轴取中位数
                 chunk_median = await self._run_cpu(self._reduce_chunk, stack)

--- a/tests/test_custom_ops.py
+++ b/tests/test_custom_ops.py
@@ -410,6 +410,34 @@ class TestCustomOpsFallback(unittest.TestCase):
 
         np.testing.assert_allclose(got, expected, rtol=1e-6, atol=1e-6)
 
+    def test_median_reduce_chunk_integer_types(self) -> None:
+        """Test uint8/uint16 with both odd and even frame counts."""
+        for dtype in (np.uint8, np.uint16):
+            # Odd frame count: exact median, no averaging
+            stack_odd = np.array(
+                [[[10, 50], [30, 40]],
+                 [[20, 40], [70, 10]],
+                 [[60, 80], [50, 90]]],
+                dtype=dtype,
+            )
+            got = median_reduce_chunk(stack_odd)
+            expected = np.median(stack_odd, axis=0).astype(dtype)
+            np.testing.assert_array_equal(got, expected,
+                                          err_msg=f"{dtype.__name__} odd-N")
+
+            # Even frame count: average of two middle values (truncated)
+            stack_even = np.array(
+                [[[10, 50], [30, 40]],
+                 [[20, 40], [70, 10]],
+                 [[60, 80], [50, 90]],
+                 [[0, 70], [20, 60]]],
+                dtype=dtype,
+            )
+            got = median_reduce_chunk(stack_even)
+            expected = np.median(stack_even, axis=0).astype(dtype)
+            np.testing.assert_array_equal(got, expected,
+                                          err_msg=f"{dtype.__name__} even-N")
+
     def test_median_reduce_chunk_can_force_numpy_fallback(self) -> None:
         stack = np.array(
             [
@@ -467,9 +495,9 @@ class TestCustomOpsFallback(unittest.TestCase):
                 self.assertEqual(patched_custom.call_count, 2)
 
         asyncio.run(run_case())
-        expected = np.median(np.stack(frames, axis=0).astype(np.float32), axis=0)
+        expected = np.median(np.stack(frames, axis=0), axis=0).astype(np.uint16)
         self.assertIn("result", outputs)
-        np.testing.assert_allclose(outputs["result"].data, expected, rtol=1e-6, atol=1e-6)
+        np.testing.assert_array_equal(outputs["result"].data, expected)
 
     def test_fgp_accumulate_matches_python_unweighted(self) -> None:
         base = FastGaussianParam(


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                        
  - Add native uint8/uint16 support to the C++ median kernel, eliminating float conversion on entire frame stacks
  - Template `median_average<T>` with `if constexpr` for type-appropriate averaging (int64 widening for integers, *0.5 for floats)                                                                                  
  - Python validation layer updated to accept uint8/uint16; numpy fallback casts result back to input dtype                                                                                                         
  - MedianReduceOp removes all `.astype(np.float32)` from stack allocation and reduction                                                                                                                            
  - Bench backend stacks use source dtype; removed obsolete float32 baseline case                                                                                                                                   
                                                                                                                                                                                                                    
  ## Test plan                                                                                                                                                                                                      
  - [x] Compiled backend correctness verified for uint8/uint16/float32/float64 (odd + even frame counts)
  - [x] Numpy fallback matches compiled behavior for all supported dtypes                                                                                                                                           
  - [x] Linux build passes (GCC + OpenMP)
  - [ ] Windows CI green (MSVC)                                                                                                                                                                                     
                                                                       